### PR TITLE
네트워크 ID 상수 업데이트: ACC에서 KIOS로 마이그레이션

### DIFF
--- a/screens/initScreens/ShopReg.js
+++ b/screens/initScreens/ShopReg.js
@@ -53,8 +53,8 @@ const ShopReg = observer(({ navigation }) => {
       const shopId = ContractUtils.getShopId(
         secretStore.address,
         secretStore.network === 'testnet'
-          ? LoyaltyNetworkID.ACC_TESTNET
-          : LoyaltyNetworkID.ACC_MAINNET,
+          ? LoyaltyNetworkID.TESTNET
+          : LoyaltyNetworkID.MAINNET,
       );
       userStore.setShopId(shopId);
       userStore.setShopName(formik.values?.n1);


### PR DESCRIPTION
- LoyaltyNetworkID의 테스트넷 및 메인넷 상수를 ACC에서 KIOS로 변경
- ShopReg 화면에서 네트워크 ID 참조 업데이트